### PR TITLE
fix `put` with custom headers

### DIFF
--- a/lib/upyun.ex
+++ b/lib/upyun.ex
@@ -364,9 +364,11 @@ defmodule Upyun do
       {:"Date"          , time()}
     ]
 
+    hds = Enum.map(opts[:headers] || [], fn {k, v} -> {:"#{k}", v} end)
+
     Keyword.merge(
       defaults,
-      opts[:headers] || []
+      hds
     )
   end
 
@@ -407,3 +409,4 @@ defmodule Upyun do
   end
 
 end
+


### PR DESCRIPTION
should convert key to atom if necessary for Keyword.merge:

```elixir
(ArgumentError) expected a keyword list as the second argument, got: [{"Content-Type", "text/plain"}]
```